### PR TITLE
WIP: Rename the permission to look more generic, refactor as they are very similar

### DIFF
--- a/ifbcatsandbox_api/permissions.py
+++ b/ifbcatsandbox_api/permissions.py
@@ -23,33 +23,18 @@ class UpdateOwnProfile(permissions.BasePermission):
          # i.e. will return True if they're trying to update their own profile.
         return obj.id == request.user.id
 
-# Custom permissions class for updating news items
-class UpdateOwnNewsItems(permissions.BasePermission):
-    """Allow users to update their own news items."""
+
+# Custom permissions class for updating object
+class PubliclyReadableEditableByOwner(permissions.BasePermission):
+    """Allow everyone to see, but only owner to update/delete."""
 
     def has_object_permission(self, request, view, obj):
-        """Check the user is trying to update their own news item."""
+        """Check the user is trying to update their own object."""
 
         if request.method in permissions.SAFE_METHODS:
             return True
 
-        # Check that the user owns the news item, i.e. the user profile associated
-        # with the news item is assigned to the user making the request.
+        # Check that the user owns the object, i.e. the user_profile associated
+        # with the object is assigned to the user making the request.
         # (returns True if the object being updated etc. has a user profile id that matches the request)
-        return obj.user_profile.id == request.user.id
-
-
-
-# Custom permissions class for updating events & event keywords
-# NB. code is identical to UpdateOwnNewsItems above, so if this really turns
-# out to be generic, will need to refactor (to use single function only)!
-class UpdateOwnEvents(permissions.BasePermission):
-    """Allow users to update their own news items."""
-
-    def has_object_permission(self, request, view, obj):
-        """Check the user is trying to update their own event."""
-
-        if request.method in permissions.SAFE_METHODS:
-            return True
-
         return obj.user_profile.id == request.user.id

--- a/ifbcatsandbox_api/views.py
+++ b/ifbcatsandbox_api/views.py
@@ -172,7 +172,7 @@ class NewsItemViewSet(viewsets.ModelViewSet):
     # i.e. they cannot create new feed items when they're not autheticated.
     # NB. Could instead use "IsAuthenticated" to restrict access of the entire endpoint to autheticated users.
     permission_classes = (
-        permissions.UpdateOwnNewsItems,
+        permissions.PubliclyReadableEditableByOwner,
         IsAuthenticatedOrReadOnly
     )
 
@@ -199,7 +199,7 @@ class EventViewSet(viewsets.ModelViewSet):
     queryset = models.Event.objects.all()
 
     permission_classes = (
-        permissions.UpdateOwnEvents,
+        permissions.PubliclyReadableEditableByOwner,
         IsAuthenticatedOrReadOnly
     )
 
@@ -217,7 +217,7 @@ class EventKeywordViewSet(viewsets.ModelViewSet):
     queryset = models.EventKeyword.objects.all()
 
     permission_classes = (
-        permissions.UpdateOwnEvents,
+        permissions.PubliclyReadableEditableByOwner,
         IsAuthenticatedOrReadOnly
     )
 
@@ -236,7 +236,7 @@ class EventPrerequisiteViewSet(viewsets.ModelViewSet):
     queryset = models.EventPrerequisite.objects.all()
 
     permission_classes = (
-        permissions.UpdateOwnEvents,
+        permissions.PubliclyReadableEditableByOwner,
         IsAuthenticatedOrReadOnly
     )
 

--- a/todo
+++ b/todo
@@ -11,5 +11,5 @@
 6. Support generation of OpenAPI docs, see https://www.django-rest-framework.org/api-guide/schemas/
 7. See if textarea fields in browsable API (Event->Description, Event->Venue) should be non-resizable - or remove such styling if we don't go down this route for the front end
 8. See if 'id' on Event, EventKeyword etc. need to be (de)serialised  - if not update serializers.py
-9. Consolidate UpdateOwnNewsItems & UpdateOwnEvents (in permissions.py) into single function if possible / desirable
+
 10. Set "None" default values to orcidid and homepage in create_user (see https://github.com/joncison/ifbcat-sandbox/pull/2) as needed.


### PR DESCRIPTION
Hi Jon

As you pointed out in todo, the permission can be consolidated into one class, I would also say they should as it thus reduce the chance of introducing a bug only for event but not news or the other way around. I also renamed the permission to be more explicite in its name, it helps futur developer knowing which permission to user directly. You indeed can imagine an other permission named ``PubliclyReadableEditableByOwnerOrGranted`` where we can assume that there will be a list of granted user, and that they can edit the object.

This PR is just a proposition, feel free to merge of just read it.

Cheers!