### PR TITLE
Using HyperlinkedRelatedField to expose organisation

### DIFF
--- a/ifbcatsandbox_api/models.py
+++ b/ifbcatsandbox_api/models.py
@@ -298,7 +298,7 @@ class Organisation(models.Model):
         settings.AUTH_USER_MODEL,
         null=True,
         on_delete=models.SET_NULL)
-    name = models.CharField(max_length=255, help_text="Name of the organisation.")
+    name = models.CharField(max_length=255, unique=True, help_text="Name of the organisation.")
     description = models.TextField(help_text="Short description of the organisation.")
     homepage = models.URLField(max_length=255, help_text="Homepage of the organisation.")
     orgid = models.CharField(max_length=255, null=True, blank=True, unique=True, help_text="Organisation ID (GRID or ROR ID) of the organisation.")

--- a/ifbcatsandbox_api/models.py
+++ b/ifbcatsandbox_api/models.py
@@ -11,6 +11,7 @@
 # so the translation occurs when the value is accessed rather than when they’re called.  We need this behaviour so
 # users will see the right language in their UI - see https://simpleisbetterthancomplex.com/tips/2016/10/17/django-tip-18-translations.html
 # See https://simpleisbetterthancomplex.com/tips/2016/10/17/django-tip-18-translations.html
+from django.core import validators
 from django.db import models
 from django.contrib.auth.models import AbstractBaseUser
 from django.contrib.auth.models import PermissionsMixin
@@ -298,7 +299,12 @@ class Organisation(models.Model):
         settings.AUTH_USER_MODEL,
         null=True,
         on_delete=models.SET_NULL)
-    name = models.CharField(max_length=255, unique=True, help_text="Name of the organisation.")
+    name = models.CharField(
+        max_length=255, unique=True, help_text="Name of the organisation.",
+        validators=[
+            validators.RegexValidator(r'^[a-zA-Z0-9 \-_~]+$', 'Should only contains char such as ^[a-zA-Z0-9\-_~]' ),
+        ],
+    )
     description = models.TextField(help_text="Short description of the organisation.")
     homepage = models.URLField(max_length=255, help_text="Homepage of the organisation.")
     orgid = models.CharField(max_length=255, null=True, blank=True, unique=True, help_text="Organisation ID (GRID or ROR ID) of the organisation.")

--- a/ifbcatsandbox_api/serializers.py
+++ b/ifbcatsandbox_api/serializers.py
@@ -256,11 +256,13 @@ class EventSerializer(serializers.ModelSerializer):
         read_only=False,
         slug_field="name",
         queryset=models.Community.objects.all())
-    hostedBy = CreatableSlugRelatedField(
+    hostedBy = serializers.HyperlinkedRelatedField(
         many=True,
         read_only=False,
-        slug_field="name",
-        queryset=models.Organisation.objects.all())
+        lookup_field="name",
+        view_name='organisation-detail',
+        queryset=models.Organisation.objects,
+    )
 
 #    accessibility = serializers.ChoiceField(
 #         choices = ('Public', 'Private'),

--- a/ifbcatsandbox_api/views.py
+++ b/ifbcatsandbox_api/views.py
@@ -265,6 +265,7 @@ class OrganisationViewSet(viewsets.ModelViewSet):
 
     serializer_class = serializers.OrganisationSerializer
     queryset = models.Organisation.objects.all()
+    lookup_field = 'name'
 
     permission_classes = (
         permissions.PubliclyReadableByUsers,


### PR DESCRIPTION
Also ensure that name is unique after behavior seen in EventSerializer

Here is an example on how to link data, the json response look like:
```
"market": "",
        "elixirPlatforms": [
            "Data"
        ],
        "communities": [
            "3D-BioInfo"
        ],
        "hostedBy": [
            "http://localhost:8092/api/organisation/EDAM-Browser/"
        ]
```

and the link is clickable, also the name of the plateform is straightforward to see. Only restriction is to have url compatible char in the name; i.e no `\n`, nor `/`

